### PR TITLE
[Draft do not merge] PR for Review Round 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ __pycache__/
 # vim
 *.swp
 
-# ipython notebooks
-notebooks/*.ipynb
+# ipython notebooks (use jupytext --sync for conversion)
+notebooks/**/*.ipynb
 
 # Ignore output files
 data/out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Emissions
 
+## 2024-03-21
+
+- gridded dataset for 2015-2100 in 10-year for 1 scenario:
+  - RESCUE-Tier1-Direct-2023-12-13-PkBudg500-OAE_on
+
+### Gridding
+
+- The separate `CO2_em_removal` variables were integrated as new sectors into the
+  `CO2_em_anthro` variable for all types of negative emissions: *Afforestation*,
+  *BECCS*, *DACCS*, *EW*, *Industry* and *OAE*.
+- The gridded scenario data starts in 2015 (where 2015-2020 derives from a custom
+  CEDS2017 extension)
+- Consistent data form:
+  - Dimensions are ordered `time`, `level` or `sector`, `lat`, `lon`
+  - Sector coordinates have guaranteed orders:
+    - `{gas}_em_anthro` variables have: `Agriculture`, `Energy`,
+      `Industrial`,`Transportation`, `Residential, Commercial, Other`,
+      `Solvents Production and Application`, `Waste`, `International Shipping`
+    - `CO2_em_anthro` variables have the same sectors, but in addition the negative
+      emissions sectors: `CDR Afforestation`, `CDR BECCS`, `CDR DACCS`, `CDR EW`,
+      `CDR Industry`, `CDR OAE`
+    - `{gas}_em_openburning` has: `Agricultural Waste Burning`, `Forest Burning`,
+      `Grassland Burning`, `Peat Burning`
+  - Data type is `float32`
+  - Time dimension is monthly in the years 2015, 2020, 2030, ..., 2100.
+
+**WARNING**: Since not all proxy discussions have concluded, *Afforestation*, *BECCS*,
+*EW* and *OAE* are only provided as nan values in this preliminary review round.
+
+### REMIND-MAgpIE
+
+No updates.
+
 ## 2023-12-08
 
 - dataset for 1995-2100 in 10-year timesteps for 6 scenarios.
@@ -47,11 +80,10 @@ Maintained in separate repository by PIK's MagPIE team.
 - transitions in 2100 are net-zero gross transitions (to be used for extended (2100-2300) scenarios)
 - cover all LUH cells (e.g. Greenland was missing before)
 
-
 ## 2023-10-11
 
 - dataset for 1995-2100 in 5-year timesteps for one scenario
 - states.nc: reporting all LUH variables except secma, secmb
 - management.nc: reporting all LUH variables except fulwd, rndwd, combf, flood, fharv_c3per, fharv_c4per
 - additionally reporting 2nd gen biofuel (crpbf2_c3per, crpbf2_c4per) and managed forests (manaf) in management.nc
-852 bytes transferred in 3 seconds (281 B/s)
+  852 bytes transferred in 3 seconds (281 B/s)

--- a/data/variabledefs-rescue.csv
+++ b/data/variabledefs-rescue.csv
@@ -43,7 +43,7 @@ CO2,CDR BECCS,Mt CO2/yr,FALSE,TRUE,TRUE,,,
 CO2,CDR DACCS,Mt CO2/yr,FALSE,TRUE,TRUE,CDR_CO2.nc,CO2_em_anthro,DAC_CDR
 CO2,CDR EW,Mt CO2/yr,FALSE,TRUE,TRUE,,,
 CO2,CDR Industry,Mt CO2/yr,FALSE,TRUE,TRUE,CDR_CO2.nc,CO2_em_anthro,IND_CDR
-CO2,CDR OAE Uptake Ocean,Mt CO2/yr,FALSE,TRUE,TRUE,CDR_CO2.nc,CO2_em_anthro,OAE_CDR
+CO2,CDR OAE Uptake Ocean,Mt CO2/yr,FALSE,TRUE,TRUE,,,
 CO,Agricultural Waste Burning,Mt CO/yr,FALSE,TRUE,TRUE,openburning_CO.nc,CO_em_openburning,AWB
 CO,Agriculture,Mt CO/yr,FALSE,TRUE,TRUE,anthro_CO.nc,CO_em_anthro,AGR
 CO,Aircraft,Mt CO/yr,TRUE,TRUE,TRUE,aircraft_CO.nc,CO_em_AIR_anthro,AIR

--- a/data/variabledefs-rescue.csv
+++ b/data/variabledefs-rescue.csv
@@ -1,4 +1,4 @@
-gas,sector,unit,global,has_history,gridded,proxy_path,proxy_name,proxy_sector
+gas,sector,unit,global,include_in_total,gridded,proxy_path,proxy_name,proxy_sector
 BC,Agricultural Waste Burning,Mt BC/yr,FALSE,TRUE,TRUE,openburning_BC.nc,BC_em_openburning,AWB
 BC,Agriculture,Mt BC/yr,FALSE,TRUE,TRUE,anthro_BC.nc,BC_em_anthro,AGR
 BC,Aircraft,Mt BC/yr,TRUE,TRUE,TRUE,aircraft_BC.nc,BC_em_AIR_anthro,AIR
@@ -28,7 +28,7 @@ CH4,Solvents Production and Application,Mt CH4/yr,FALSE,TRUE,TRUE,anthro_CH4.nc,
 CH4,Transportation Sector,Mt CH4/yr,FALSE,TRUE,TRUE,anthro_CH4.nc,CH4_em_anthro,TRA
 CH4,Waste,Mt CH4/yr,FALSE,TRUE,TRUE,anthro_CH4.nc,CH4_em_anthro,WST
 CO2,Aggregate - Agriculture and LUC,Mt CO2/yr,TRUE,TRUE,FALSE,,,
-CO2,Agriculture,Mt CO2/yr,TRUE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,AGR
+CO2,Agriculture,Mt CO2/yr,TRUE,FALSE,TRUE,anthro_CO2.nc,CO2_em_anthro,AGR
 CO2,Aircraft,Mt CO2/yr,TRUE,TRUE,TRUE,aircraft_CO2.nc,CO2_em_AIR_anthro,AIR
 CO2,Energy Sector|Modelled,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,ENE
 CO2,Energy Sector|Non-Modelled,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,ENE
@@ -39,11 +39,11 @@ CO2,Solvents Production and Application,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,
 CO2,Transportation Sector,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,TRA
 CO2,Waste,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,WST
 CO2,CDR Afforestation,Mt CO2/yr,FALSE,FALSE,TRUE,,,
-CO2,CDR BECCS,Mt CO2/yr,FALSE,FALSE,TRUE,,,
-CO2,CDR DACCS,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,DAC_CDR
-CO2,CDR EW,Mt CO2/yr,FALSE,FALSE,TRUE,,,
-CO2,CDR Industry,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,IND_CDR
-CO2,CDR OAE Uptake Ocean,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,OAE_CDR
+CO2,CDR BECCS,Mt CO2/yr,FALSE,TRUE,TRUE,,,
+CO2,CDR DACCS,Mt CO2/yr,FALSE,TRUE,TRUE,CDR_CO2.nc,CO2_em_anthro,DAC_CDR
+CO2,CDR EW,Mt CO2/yr,FALSE,TRUE,TRUE,,,
+CO2,CDR Industry,Mt CO2/yr,FALSE,TRUE,TRUE,CDR_CO2.nc,CO2_em_anthro,IND_CDR
+CO2,CDR OAE Uptake Ocean,Mt CO2/yr,FALSE,TRUE,TRUE,CDR_CO2.nc,CO2_em_anthro,OAE_CDR
 CO,Agricultural Waste Burning,Mt CO/yr,FALSE,TRUE,TRUE,openburning_CO.nc,CO_em_openburning,AWB
 CO,Agriculture,Mt CO/yr,FALSE,TRUE,TRUE,anthro_CO.nc,CO_em_anthro,AGR
 CO,Aircraft,Mt CO/yr,TRUE,TRUE,TRUE,aircraft_CO.nc,CO_em_AIR_anthro,AIR

--- a/data/variabledefs-rescue.csv
+++ b/data/variabledefs-rescue.csv
@@ -40,10 +40,10 @@ CO2,Transportation Sector,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,
 CO2,Waste,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,WST
 CO2,CDR Afforestation,Mt CO2/yr,FALSE,FALSE,TRUE,,,
 CO2,CDR BECCS,Mt CO2/yr,FALSE,FALSE,TRUE,,,
-CO2,CDR DACCS,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_removal,DAC_CDR
+CO2,CDR DACCS,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,DAC_CDR
 CO2,CDR EW,Mt CO2/yr,FALSE,FALSE,TRUE,,,
-CO2,CDR Industry,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_removal,IND_CDR
-CO2,CDR OAE,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_removal,OAE_CDR
+CO2,CDR Industry,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,IND_CDR
+CO2,CDR OAE,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,OAE_CDR
 CO,Agricultural Waste Burning,Mt CO/yr,FALSE,TRUE,TRUE,openburning_CO.nc,CO_em_openburning,AWB
 CO,Agriculture,Mt CO/yr,FALSE,TRUE,TRUE,anthro_CO.nc,CO_em_anthro,AGR
 CO,Aircraft,Mt CO/yr,TRUE,TRUE,TRUE,aircraft_CO.nc,CO_em_AIR_anthro,AIR

--- a/data/variabledefs-rescue.csv
+++ b/data/variabledefs-rescue.csv
@@ -43,7 +43,7 @@ CO2,CDR BECCS,Mt CO2/yr,FALSE,FALSE,TRUE,,,
 CO2,CDR DACCS,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,DAC_CDR
 CO2,CDR EW,Mt CO2/yr,FALSE,FALSE,TRUE,,,
 CO2,CDR Industry,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,IND_CDR
-CO2,CDR OAE,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,OAE_CDR
+CO2,CDR OAE Uptake Ocean,Mt CO2/yr,FALSE,FALSE,TRUE,CDR_CO2.nc,CO2_em_anthro,OAE_CDR
 CO,Agricultural Waste Burning,Mt CO/yr,FALSE,TRUE,TRUE,openburning_CO.nc,CO_em_openburning,AWB
 CO,Agriculture,Mt CO/yr,FALSE,TRUE,TRUE,anthro_CO.nc,CO_em_anthro,AGR
 CO,Aircraft,Mt CO/yr,TRUE,TRUE,TRUE,aircraft_CO.nc,CO_em_AIR_anthro,AIR

--- a/data/variabledefs-rescue.csv
+++ b/data/variabledefs-rescue.csv
@@ -28,6 +28,7 @@ CH4,Solvents Production and Application,Mt CH4/yr,FALSE,TRUE,TRUE,anthro_CH4.nc,
 CH4,Transportation Sector,Mt CH4/yr,FALSE,TRUE,TRUE,anthro_CH4.nc,CH4_em_anthro,TRA
 CH4,Waste,Mt CH4/yr,FALSE,TRUE,TRUE,anthro_CH4.nc,CH4_em_anthro,WST
 CO2,Aggregate - Agriculture and LUC,Mt CO2/yr,TRUE,TRUE,FALSE,,,
+CO2,Agriculture,Mt CO2/yr,TRUE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,AGR
 CO2,Aircraft,Mt CO2/yr,TRUE,TRUE,TRUE,aircraft_CO2.nc,CO2_em_AIR_anthro,AIR
 CO2,Energy Sector|Modelled,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,ENE
 CO2,Energy Sector|Non-Modelled,Mt CO2/yr,FALSE,TRUE,TRUE,anthro_CO2.nc,CO2_em_anthro,ENE

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,8 @@ dependencies:
 - pooch
 - zarr
 - flox
+- pyogrio
+- geopandas
 - bottleneck
 - cf_xarray
 

--- a/environment.yml
+++ b/environment.yml
@@ -49,7 +49,7 @@ dependencies:
 
 - pip
 - pip:
-  - pandas-indexing[units] >=0.2.10
+  - pandas-indexing[units] >=0.4.1
   # Need to integrate new indexraster changes into ptolemy
   - git+https://github.com/gidden/ptolemy.git@add-index-raster#egg=ptolemy-iamc
   - git+https://github.com/iiasa/aneris.git@workflow#egg=aneris-iamc

--- a/notebooks/build-harmonization-report.py
+++ b/notebooks/build-harmonization-report.py
@@ -5,11 +5,11 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.16.0
+#       jupytext_version: 1.16.1
 #   kernelspec:
-#     display_name: Python [conda env:concordia]
+#     display_name: concordia
 #     language: python
-#     name: conda-env-concordia-py
+#     name: python3
 # ---
 
 # %%
@@ -42,7 +42,7 @@ pio.templates.default = "ggplot2"
 
 # %%
 version_old = None  # "2023-08-18"
-version = "2023-12-08"
+version = "2024-03-21"
 
 # %%
 settings = Settings.from_config(version=version)
@@ -265,21 +265,21 @@ import matplotlib.pyplot as plt
 # %%
 plot_harm(
     isin(region="CHA", sector="Energy Sector", gas="CH4"),
-    scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_off",
+    scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_on",
 )
 plt.legend(labels=["CEDS", "CMIP6", "Unharmonized", "Harmonized"], frameon=False)
 
 # %%
 g = plot_harm(
     isin(sector="Total", gas="CO2"),
-    scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_off",
+    scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_on",
     useplotly=False,
 )
 
 # %%
 g = plot_harm(
     isin(sector="Aggregate - Agriculture and LUC", gas="CO2"),
-    scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_off",
+    scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_on",
     useplotly=False,
 )
 

--- a/notebooks/gridding_data/generate_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_ceds_proxy_netcdfs.py
@@ -40,6 +40,7 @@ from concordia.settings import Settings
 
 settings = Settings.from_config("../config.yaml", version=None)
 
+dim_order = ["gas", "sector", "level", "year", "month", "lat", "lon"]
 
 sector_mapping = {
     "anthro": ["AGR", "ENE", "IND", "TRA", "RCO", "SLV", "WST"],
@@ -348,7 +349,7 @@ def gen_da_for_gas(gas, sector_key, with_dask=True):
         print(gas, sector)
         da = gen_da_for_sector(gas, sector, with_dask=with_dask)
         das.append(da)
-    return xr.concat(das, "sector")
+    return xr.concat(das, "sector").transpose(*dim_order, missing_dims="ignore")
 
 
 # # Full Processing

--- a/notebooks/gridding_data/generate_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_ceds_proxy_netcdfs.py
@@ -123,12 +123,11 @@ df_files = df_files[df_files["year"].isin(years)]
 # **Rows are latitudes, Columns are longitudes**
 def mask_to_ary(row):
     a = pyreadr.read_r(row.file)[f"{row.iso}_mask"]
-    lat = template.lat[row.start_row - 1 : row.end_row]
+    lat = template.lat[::-1][row.start_row - 1 : row.end_row]
     lon = template.lon[row.start_col - 1 : row.end_col]
     da = xr.DataArray(
         np.asarray(a, dtype="float32"), coords={"lat": lat, "lon": lon}
     ).reindex(lat=template.lat, lon=template.lon, fill_value=0)
-    da["lat"] = da["lat"] * -1  # NB: Inversion!
     return da
 
 
@@ -223,7 +222,7 @@ def gen_indexraster():
 def read_r_variable(file):
     print(f"Reading in {file}\n")
     a = pyreadr.read_r(file)[file.stem]
-    return np.asarray(a, dtype="float32")
+    return np.asarray(a, dtype="float32")[::-1]
 
 
 @lru_cache
@@ -257,7 +256,6 @@ def make_year_ary(fname, air=False, waste=False, with_dask=True):
         da = xr.where(da > threshold, threshold, da)
         # cast back to total people
         da = da * grid_area_m2
-    da["lat"] = da["lat"] * -1  # NB: Inversion!
     return da
 
 
@@ -304,7 +302,6 @@ def make_season_ary(fname, air=False, with_dask=True):
     else:
         a = read_func(fname)
     da = xr.DataArray(a, coords=coords, name=name)
-    da["lat"] = da["lat"] * -1  # NB: Inversion!
     return da
 
 

--- a/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
@@ -77,6 +77,7 @@ def mariteam_shipping():
                 .assign_coords(gas=[gas])
                 .transpose(*dim_order, missing_dims="ignore")
                 .astype("float32")
+                .sel(lat=slice(None, None, -1))
             )
 
     for gas in gases:

--- a/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
@@ -69,7 +69,7 @@ def mariteam_shipping():
         # make sure gas name is aligned with gas arg
         print(f"For gas {gas}, using {pth}")
         with xr.open_dataarray(pth) as da:
-            return da.drop_vars(["gas"]).assign_coords(gas=[gas])
+            return da.drop_vars(["gas"]).assign_coords(gas=[gas]).astype("float32")
 
     for gas in gases:
         da = convert_mariteam_to_ceds(mari, gas)
@@ -85,6 +85,7 @@ mariteam_shipping()
 # # CDR
 #
 # We provide proxies for several CDR technologies:
+#
 # 1. OAE CDR re-uses shipping CO2 emissions
 # 2. DACCS CDR incorporates renewable potentials and CO2 storage potentials
 # 3. Industry CDR uses the composition of renewables, CO2 storage and industry co2 emissions
@@ -99,9 +100,14 @@ ind_co2
 
 # %% [markdown]
 # # OAE CDR and emissions
+#
+
+# %% [markdown]
+#
 
 # %% [markdown]
 # Use shipping CO2 for OAE CDR emissions
+#
 
 # %%
 oae_cdr = (
@@ -112,11 +118,13 @@ oae_cdr = (
 
 # %% [markdown]
 # **TODO** We might want to try to give the OAE CDR negative emissions some seasonality that correlates with industry emissions. Unfortunately, the industry co2 seasonality is different between regions (compare `ind_co2.sel(lon=slice(0, 20), lat=slice(40, 20)).mean(["year", "gas", "lat", "lon"]).plot()` (Europe) to `ind_co2.sel(lon=slice(0, 20), lat=slice(-10, 30)).mean(["year", "gas", "lat", "lon"]).plot()` (Africa))
+#
 
 # %% [markdown]
 # # DACCS and Industrial CDR
 #
 # Combine renewable potential from GaSP, Global Wind and Solar Atlas with CO2 storage potential
+#
 
 # %%
 renewable_potential = gu.Raster(
@@ -231,6 +239,7 @@ missing_countries(dac_cdr.sel(month=1, year=2050, gas="CO2"))
 
 # %% [markdown]
 # # Combine and Save
+#
 
 # %%
 da = (
@@ -247,9 +256,6 @@ da = (
     .transpose("lat", "lon", "gas", "sector", "year", "month")
     .astype("float32")
 )
-
-# %%
-da
 
 # %%
 da.to_netcdf(

--- a/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
@@ -94,7 +94,7 @@ mariteam_shipping()
 #
 # We provide proxies for several CDR technologies:
 #
-# 1. OAE CDR re-uses shipping CO2 emissions
+# 1. OAE CDR re-uses shipping CO2 emissions (to be updated and spread evenly into EEZ)
 # 2. DACCS CDR incorporates renewable potentials and CO2 storage potentials
 # 3. Industry CDR uses the composition of renewables, CO2 storage and industry co2 emissions
 #
@@ -254,7 +254,7 @@ da = (
     xr.concat(
         [
             ind_cdr,
-            oae_cdr,
+            # oae_cdr,
             # oae_co2, # Part of other emissions
             dac_cdr,
         ],

--- a/notebooks/workflow.py
+++ b/notebooks/workflow.py
@@ -64,7 +64,7 @@ ur = set_openscm_registry_as_default()
 #
 
 # %%
-settings = Settings.from_config(version="2023-03-13")
+settings = Settings.from_config(version="2024-03-13")
 
 # %%
 fh = logging.FileHandler(settings.out_path / f"debug_{settings.version}.log", mode="w")

--- a/notebooks/workflow.py
+++ b/notebooks/workflow.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import dask
 import pandas as pd
 from dask.distributed import Client
-from pandas_indexing import concat, isin, semijoin
+from pandas_indexing import concat, isin, ismatch, semijoin
 from pandas_indexing.units import set_openscm_registry_as_default
 from ptolemy.raster import IndexRaster
 
@@ -64,7 +64,7 @@ ur = set_openscm_registry_as_default()
 #
 
 # %%
-settings = Settings.from_config(version="2024-03-13")
+settings = Settings.from_config(version="2024-03-18")
 
 # %%
 fh = logging.FileHandler(settings.out_path / f"debug_{settings.version}.log", mode="w")
@@ -261,11 +261,16 @@ gdp = semijoin(
 # %%
 # Test with one scenario only
 if True:
-    num_scenarios = 1
-    model = model.pix.semijoin(
-        model.pix.unique(["model", "scenario"])[:num_scenarios], how="right"
-    )
-    logger().warning("Testing with only %d scenario(s)", num_scenarios)
+    model = model.loc[ismatch(scenario="RESCUE-Tier1-Direct-*-PkBudg500-OAE_on")]
+
+    # model = model.pix.semijoin(
+    #     model.pix.unique(["model", "scenario"])[:2], how="right"
+    # )
+logger().info(
+    "Running with %d scenario(s):\n- %s",
+    len(model.pix.unique(["model", "scenario"])),
+    "\n- ".join(model.pix.unique("scenario")),
+)
 
 # %%
 client = Client()

--- a/notebooks/workflow.py
+++ b/notebooks/workflow.py
@@ -141,7 +141,9 @@ hist_global = (
     .rename_axis(index=str.lower)
     .rename_axis(index={"region": "country"})
     .rename(
-        index=lambda s: s.removesuffix("|Unharmonized") + "|Total", level="variable"
+        index=lambda s: s.removesuffix("|Unharmonized")
+        + ("|Total" if "Agriculture and LUC" not in s else ""),
+        level="variable",
     )
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "cattrs",
   "ptolemy-iamc>=0.3",
   "aneris-iamc>=0.2.6",
-  "pandas-indexing>=0.2.10",
+  "pandas-indexing>=0.4.1",
   "pycountry",
   "python-slugify",
   "dominate",

--- a/src/concordia/downscale.py
+++ b/src/concordia/downscale.py
@@ -14,6 +14,9 @@ def downscale(
     regionmapping: RegionMapping,
     settings: Settings,
 ) -> pd.DataFrame:
+    if harmonized.empty:
+        return harmonized.pix.assign(country=[], method=[])
+
     downscaler = Downscaler(
         harmonized.loc[~isin(region="World")],
         hist,

--- a/src/concordia/grid.py
+++ b/src/concordia/grid.py
@@ -160,11 +160,11 @@ class Proxy:
 
         global_weight = proxy_reduced.sum(["lat", "lon"]).chunk(-1)
         if self.only_global:
-            return Weight(global_weight.persist(), None)
+            return Weight(global_weight, None)
 
         regional_weight = self.indexraster.aggregate(proxy_reduced).chunk(-1)
 
-        return Weight(*dask.persist(global_weight, regional_weight))
+        return Weight(global_weight, regional_weight)
 
     @staticmethod
     def assert_single_pathway(downscaled):
@@ -212,7 +212,7 @@ class Proxy:
             sectors = weight.indexes["sector"].intersection(scen.pix.unique("sector"))
             scen = xr.DataArray.from_series(scen).reindex(sector=sectors, fill_value=0)
             weight = weight.reindex_like(scen)
-            return (scen / weight).where(weight, 0).chunk().persist()
+            return (scen / weight).where(weight, 0).chunk()
 
         is_global = isin(country="World")
 

--- a/src/concordia/grid.py
+++ b/src/concordia/grid.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @dask.delayed
 def verify_global_values(
-    aggregated, tabular, proxy_name, index, abstol=1e-8, reltol=1e-8
+    aggregated, tabular, proxy_name, index, abstol=1e-8, reltol=1e-6
 ) -> pd.DataFrame:
     tab_df = tabular.groupby(level=index).sum().unstack("year")
     grid_df = aggregated.to_series().groupby(level=index).sum().unstack("year")

--- a/src/concordia/grid.py
+++ b/src/concordia/grid.py
@@ -145,7 +145,7 @@ class Proxy:
     def proxy_as_flux(self):
         da = self.data
         if self.as_flux:
-            da /= self.indexraster.cell_area.chunk().persist()
+            da /= self.indexraster.cell_area.astype(self.data.dtype, copy=False)
         return da
 
     def reduce_dimensions(self, da):
@@ -186,6 +186,7 @@ class Proxy:
             )
             .pix.project(["gas", "sector", "country", "year"])
             .sort_index()
+            .astype(self.data.dtype, copy=False)
         )
         downscaled.attrs.update(meta)
         return downscaled
@@ -195,7 +196,9 @@ class Proxy:
 
         global_gridded = self.reduce_dimensions(gridded)
         if self.as_flux:
-            global_gridded *= self.indexraster.cell_area
+            global_gridded *= self.indexraster.cell_area.astype(
+                self.data.dtype, copy=False
+            )
         global_gridded = global_gridded.sum(["lat", "lon"])
         diff = verify_global_values(
             global_gridded, scen, self.name, ("sector", "gas", "year")

--- a/src/concordia/harmonize.py
+++ b/src/concordia/harmonize.py
@@ -41,6 +41,9 @@ def _harmonize(
 def harmonize(
     model: pd.DataFrame, hist: pd.DataFrame, overrides: pd.DataFrame, settings: Settings
 ) -> pd.DataFrame:
+    if model.empty:
+        return model.loc[:, settings.base_year :].pix.assign(method=[])
+
     is_luc = isin(sector=settings.luc_sectors)
     harmonized = concat(
         skipnone(

--- a/src/concordia/harmonize.py
+++ b/src/concordia/harmonize.py
@@ -72,16 +72,19 @@ class Harmonized:
     hist: pd.DataFrame
     model: pd.DataFrame
     harmonized: pd.DataFrame
+    skip_for_total: pd.MultiIndex
 
     def drop_method(self):
         return evolve(self, harmonized=self.harmonized.droplevel("method"))
 
     def pipe(self, func: callable, *args, **kwargs):
         f = partial(func, *args, **kwargs)
-        return self.__class__(f(self.hist), f(self.model), f(self.harmonized))
+        return self.__class__(
+            f(self.hist), f(self.model), f(self.harmonized), self.skip_for_total
+        )
 
     def add_totals(self):
-        return self.pipe(add_totals)
+        return self.pipe(add_totals, skip_for_total=self.skip_for_total)
 
     def aggregate_subsectors(self):
         return self.pipe(aggregate_subsectors)

--- a/src/concordia/rescue/utils.py
+++ b/src/concordia/rescue/utils.py
@@ -149,7 +149,7 @@ def add_sector_mapping(da, sector_mapping):
             vals,
             attrs=dict(
                 long_name="sector",
-                id="; ".join(f"{v}: {k}" for v, k in zip(vals, keys)),
+                ids="; ".join(f"{v}: {k}" for v, k in zip(vals, keys)),
             ),
         )
     )

--- a/src/concordia/workflow.py
+++ b/src/concordia/workflow.py
@@ -126,7 +126,8 @@ class WorkflowDriver:
 
         def expand_subsectors(variables: pd.MultiIndex) -> pd.MultiIndex:
             """
-            Energy Sector becomes Energy Sector|Modelled and Energy Sector|Non-Modelled
+            Energy Sector becomes Energy Sector|Modelled and Energy Sector|Non-
+            Modelled.
             """
             sectors = variabledefs.index_regional.pix.unique("sector")
             return (
@@ -306,13 +307,18 @@ class WorkflowDriver:
                 variabledefs.variable_index, how="inner"
             )
 
+        downscaled, hist = downscaled.align(
+            self.hist.drop(self.settings.base_year, axis=1), join="left", axis=0
+        )
+        tabular = concat([hist, downscaled], axis=1)
+
         # Convert unit to kg/s of the repective gas
-        downscaled = downscaled.pix.convert_unit(
+        tabular = tabular.pix.convert_unit(
             lambda s: re.sub("(?:Gt|Mt|kt|t|kg) (.*)/yr", r"kg \1/s", s)
         )
 
-        for model, scenario in downscaled.pix.unique(["model", "scenario"]):
-            yield proxy.grid(downscaled.loc[isin(model=model, scenario=scenario)])
+        for model, scenario in tabular.pix.unique(["model", "scenario"]):
+            yield proxy.grid(tabular.loc[isin(model=model, scenario=scenario)])
 
     def grid(
         self,

--- a/src/concordia/workflow.py
+++ b/src/concordia/workflow.py
@@ -117,7 +117,7 @@ class WorkflowDriver:
                     ]
                 )
             ]
-        )
+        ).pix.semijoin(variabledefs.index_regional, how="inner")
         all_variables = variables.pix.unique(["gas", "sector"])
         nonzero_variables = variables.loc[abs(variables) > 0].index
         zero_variables = all_variables.difference(
@@ -129,7 +129,7 @@ class WorkflowDriver:
             Energy Sector becomes Energy Sector|Modelled and Energy Sector|Non-
             Modelled.
             """
-            sectors = variabledefs.index_regional.pix.unique("sector")
+            sectors = variabledefs.variable_index.pix.unique("sector")
             return (
                 variables.rename({"sector": "short_sector"})
                 .join(
@@ -141,7 +141,8 @@ class WorkflowDriver:
                             .str[0]
                             .rename("short_sector"),
                         ]
-                    )
+                    ),
+                    how="left",
                 )
                 .droplevel("short_sector")
             )

--- a/src/concordia/workflow.py
+++ b/src/concordia/workflow.py
@@ -362,4 +362,9 @@ class WorkflowDriver:
         hist = self.history_aggregated.data
         model = self.model.pix.semijoin(hist.index, how="right")
 
-        return Harmonized(hist=hist, model=model, harmonized=self.harmonized.data)
+        return Harmonized(
+            hist=hist,
+            model=model,
+            harmonized=self.harmonized.data,
+            skip_for_total=self.variabledefs.skip_for_total,
+        )

--- a/src/concordia/workflow.py
+++ b/src/concordia/workflow.py
@@ -276,7 +276,7 @@ class WorkflowDriver:
             downscaled.append(
                 add_zeros_like(
                     down,
-                    model,
+                    harm,
                     country=missing_countries,
                     method=["all_zero"],
                     derive=dict(region=self.regionmapping.index),
@@ -312,7 +312,7 @@ class WorkflowDriver:
             downscaled = self.harmonize_and_downscale(variabledefs)
         else:
             downscaled = downscaled.pix.semijoin(
-                variabledefs.variable_index, how="inner"
+                variabledefs.downscaling.variable_index, how="inner"
             )
 
         hist = aggregate_subsectors(self.hist.drop(self.settings.base_year, axis=1))


### PR DESCRIPTION
Fixes #32 , #34 and #36 .

- [x] Data type is used from proxy (and indexraster)
- [x] Check and correct dimension order:
  - [x] aircraft: `time`, `level`, `lat`, `lon`
  - [x] anthro: `time`, `sector`, `lat`, `lon`
  - [x] openburning: `time`, `sector`, `lat`, `lon`
- [x] Sectors are not dropped by empty proxy weights (restores Agriculture and Solvents in BC)
- [x] Sector order in proxies is preserved
- [x] Proxies need to be updated:
  - [x] Sector order in `anthro_*`-proxies should be `'AGR', 'ENE', 'IND', 'TRA', 'RCO', 'SLV', 'WST'` (currently it is alphabetical with `TRA` in between `SLV` and `WST`)
  - [x] Sector order in `openburning` is fine
  - [x] Data type should be float32 (`.astype("float32")`)
    - [x] anthro
    - [x] openburning
    - [x] aircraft
    - [x] shipping
    - [x] cdr_co2 
- [x] Sector attribute `id` is called `ids` instead
- [x] Indexraster needs to use the float32 datatype as well (or we add a quick conversion to `workflow.ipynb`)
- [x] Agriculture CO2 needs to be added as 0 (still missing because it does not have a variable correspondence in variabledefs)
- [x] Move `CO2_em_removal` into `CO2_em_anthro` with documentation
- [x] Add 2015 year to gridded data by stitching historical and downscaled tabular data
- ~[ ] `time_bnds` between two years are incorrect~ for review round 3
- ~[ ] Check there are no nan's in any of the datasets~ systematic check for review round 3
- [x] Compare to previous set of gridded files (per sector/gas spot checks and grid cell total systematically)
- [x] Add a CHANGELOG