### PR TITLE
refer to land use data changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,22 +90,4 @@ No updates.
 
 # Land Use
 
-Maintained in separate repository by PIK's MagPIE team.
-
-## 2023-12-08
-
-- dataset for 1995-2100 in 5-year timesteps for all REMIND-MAgPIE scenarios used for the emissions
-- added metadata to nc files
-- management.nc: added fulwd, rndwd
-- transitions.nc: reporting all LUH variables incl. wood harvest variables
-- all transitions are gross transitions
-- transitions in 2100 are net-zero gross transitions (to be used for extended (2100-2300) scenarios)
-- cover all LUH cells (e.g. Greenland was missing before)
-
-## 2023-10-11
-
-- dataset for 1995-2100 in 5-year timesteps for one scenario
-- states.nc: reporting all LUH variables except secma, secmb
-- management.nc: reporting all LUH variables except fulwd, rndwd, combf, flood, fharv_c3per, fharv_c4per
-- additionally reporting 2nd gen biofuel (crpbf2_c3per, crpbf2_c4per) and managed forests (manaf) in management.nc
-  852 bytes transferred in 3 seconds (281 B/s)
+Maintained in separate repository by PIK's MAgPIE team, see [here](https://github.com/pik-piam/mrdownscale/blob/main/inst/extdata/runner/changelog-rescue.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,4 +90,4 @@ No updates.
 
 # Land Use
 
-Maintained in separate repository by PIK's MAgPIE team, see [here](https://github.com/pik-piam/mrdownscale/blob/main/inst/extdata/runner/changelog-rescue.md).
+Maintained in separate repository by PIK's MAgPIE team, see [here](https://github.com/pik-piam/mrdownscale/blob/main/runner/changelog-rescue.md).


### PR DESCRIPTION
I'd suggest to link to the other changelog instead of keeping this up to date. I already added a link to this concordia changelog in our mrdownscale changelog.