### PR TITLE
fix(environment): Add lower bound for geoutils

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,7 +41,7 @@ dependencies:
 # raster generation
 - rasterio
 - rioxarray
-- geoutils >=0.1
+- geoutils >=0.1.2 # Added that version lower-bound since they introduced a python 3.11 upper bound then, limiting our environment to python 3.11 effectively
 - cartopy
 - geopandas
 - pyreadr

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - cattrs
 - pandas >=1.1
 - pandas-indexing
+- openscm-units
 - pyyaml
 - xlrd >=2.0
 - openpyxl


### PR DESCRIPTION
Grr.. another geoutils upper bound making trouble in the end.

They bounded python to <3.12 starting from 0.1.2.

Need to force mamba to use that!

Included also the missing openscm-units dependency observed in #45 (pt. 12)