### PR TITLE
fix: Rely on typing-extensions package for backward-compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
 
 # Make docstrings PEP 257 compliant
 - repo: https://github.com/PyCQA/docformatter
-  rev: v1.7.5
+  rev: 06907d0  # Update to new version when https://github.com/PyCQA/docformatter/issues/293 is closed
   hooks:
   - id: docformatter
     args: ["--in-place", "--make-summary-multi-line"]

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: concordia
 channels:
 - conda-forge
 dependencies:
+- typing-extensions
 - attrs
 - cattrs
 - pandas >=1.1

--- a/src/concordia/grid.py
+++ b/src/concordia/grid.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 from collections import namedtuple
-from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import dask
 import pandas as pd
@@ -14,6 +14,10 @@ from attrs import define, field
 from pandas_indexing import isin
 
 from .utils import Pathy, VariableDefinitions
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 logger = logging.getLogger(__name__)

--- a/src/concordia/settings.py
+++ b/src/concordia/settings.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Self
+from typing import TYPE_CHECKING
 
 import yaml
 from attrs import define
 from cattrs import structure, transform_error
 from cattrs.errors import ClassValidationError
 
+from .utils import Pathy
 
-Pathy = str | Path
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
 @define

--- a/src/concordia/utils.py
+++ b/src/concordia/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from functools import reduce
 from itertools import chain, product
 from pathlib import Path
-from typing import Self, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 import dask.distributed as dd
 import numpy as np
@@ -18,11 +18,14 @@ from pandas import DataFrame, isna
 from pandas.api.types import is_iterator, is_list_like
 from pandas_indexing import concat, isin
 
-from .settings import Settings
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from .settings import Settings
 
 
 logger = logging.getLogger(__name__)
-
 
 Pathy: TypeAlias = str | Path
 

--- a/src/concordia/workflow.py
+++ b/src/concordia/workflow.py
@@ -4,9 +4,9 @@ import logging
 import re
 import textwrap
 from collections import namedtuple
-from collections.abc import Callable, Iterator, Sequence
 from functools import cached_property
 from itertools import chain
+from typing import TYPE_CHECKING
 
 import dask
 import pandas as pd
@@ -28,6 +28,10 @@ from .utils import (
     aggregate_subsectors,
     skipnone,
 )
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Sequence
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #65

Thanks for the typing-extensions tip.
