### PR TITLE
Make proxies proportional to fluxes

### DIFF
--- a/notebooks/gridding_data/generate_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_ceds_proxy_netcdfs.py
@@ -247,8 +247,19 @@ def make_year_ary(fname, air=False, waste=False, with_dask=True):
     else:
         a = read_r_variable(fname)
 
+    da = xr.DataArray(a, coords=coords, name=name)
+
     # convert to emissions value per m2
-    da = xr.DataArray(a, coords=coords, name=name) / grid_area_m2()
+
+    # not for air, because they are already given as a flux in the CEDS-files zenodo
+    # dump from 2019. The full context is difficult, but some information is in the
+    # ticket: https://github.com/JGCRI/CEDS/issues/45
+
+    # TODO: If new proxy files should be used for air, then they will be distributed
+    # by ceds again in terms of emissions and will then need to be divided by cell areas
+    # to convert to fluxes.
+    if not air:
+        da = da / grid_area_m2()
     if waste:
         # For any grid cell has a population density greater than the 1000
         # people/sq mile threshold, the population density for that grid cell is

--- a/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
+++ b/notebooks/gridding_data/generate_non_ceds_proxy_netcdfs.py
@@ -145,6 +145,7 @@ rasterize.read_shpf(
 oae_cdr = (
     rasterize.rasterize(strategy="weighted", normalize_weights=False)
     .sel(index=0, drop=True)
+    .where(ind_co2["lat"] <= 67.5, 0)  # restrict to 67.5º like in OceanNET
     .assign_coords(gas="CO2", sector="OAE_CDR")
     * ind_co2_dimensions
 )
@@ -369,7 +370,7 @@ def rasterize_nonurbanland(year, buffer="25km"):
         / f"Buffer_{buffer}_Urb_Boundary_{year}_SSP.shp"
     )
     nonurban = gpd.GeoSeries(
-        [land.to_crs(urban.crs).unary_union.difference(urban.unary_union)],
+        [land.to_crs(urban.crs).union_all().difference(urban.union_all())],
         crs=urban.crs,
     )
 

--- a/src/concordia/workflow.py
+++ b/src/concordia/workflow.py
@@ -101,7 +101,6 @@ class WorkflowDriver:
                 self.variabledefs.for_proxy(output_variable),
                 dict(country=self.indexraster_country, region=self.indexraster_region),
                 self.settings.proxy_path,
-                as_flux=True,
             )
             for output_variable in self.variabledefs.proxies
         }


### PR DESCRIPTION
# Description

## Convention update
CEDS proxies were designed to be proportional to absolute emissions in each grid cell and we adopted that convention unknowingly.

This PR is changing this design to make uniform proxies that are used for CDR like OAE more intuitive. This means that all CEDS proxies need to be divided by the cell area on import.

This happened in the generation scripts also updated in this PR, but also in the new data folder on OneDrive labelled data_2024_09_16 . Proxy rasters for the code for this PR need to be regenerated or used from the new OneDrive folder. (NB @jkikstra).

## OAE Alkalinity Additions
OAE Alkalinity additions are not deployed above 67.5ºN any longer (due to efficiency concerns).

## Fix CEDS Aircraft emissions proxy

As reported in  https://gmd.copernicus.org/preprints/gmd-2022-250/ and https://github.com/JGCRI/CEDS/issues/45 :

- input4MIPS historical files came with a bias of 1/cos(lat), while
- input4MIPS scenario files had even a 1/cos(lat)**2 bias

These resulted from two mistakes in proxy generation scripts.
    
We half-fix the scenario files bias to 1/cos(lat) to be consistent with historical gridded emissions.

(@jkikstra @gidden This half-fix in commit ac85fd1 has to be undone, when the CEDS Aircraft emissions proxies will be updated, but hopefully you can find a better format than the current R dumps, which will make the current hacky script obsolete)

Remaining known problem:
- New scenario files have still a 1/cos(lat) bias to be consistent with historical files
  
